### PR TITLE
install and test poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM buildpack-deps:bookworm AS base
 ENV CACHEBUST=2024-09-06
 RUN apt update
 
-# Rust envvars
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     RUST_VERSION=1.81.0 \
     VIRTUAL_ENV=/var/local/python-venv
-ENV PATH=/usr/local/cargo/bin:$VIRTUAL_ENV/bin:$PATH
+ENV PATH=/usr/local/cargo/bin:$VIRTUAL_ENV/bin:/root/.local/bin:$PATH
 
 # == node ======================
 FROM base AS node
@@ -33,6 +32,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=framework-runtime-python \
       python3-wheel \
       python3-dev \
       python3-venv \
+      pipx \
+    && pipx install poetry \
     && python3 -m venv $VIRTUAL_ENV
 
 # == R ===========================

--- a/bin/test.ts
+++ b/bin/test.ts
@@ -5,6 +5,13 @@ import { dirname } from "node:path";
 import { run as runTests } from "node:test";
 import { spec } from "node:test/reporters";
 
+import { parseArgs } from "node:util";
+const { values: { "only": argOnly } } = parseArgs({
+  options: {
+    "only": { type: "boolean" },
+  }
+});
+
 export async function buildTestImage() {
   console.log("building image...");
   let stdio = new StringStream();
@@ -34,7 +41,7 @@ const files = await glob(["tests/**/*.test.ts"], {
 });
 
 await buildTestImage();
-runTests({ files, concurrency: true })
+runTests({ files, concurrency: true, only: argOnly })
   .on("test:fail", () => {
     process.exitCode = 1;
   })

--- a/tests/dataloader-languages.test.ts
+++ b/tests/dataloader-languages.test.ts
@@ -1,4 +1,5 @@
 import { test, describe } from "node:test";
+import os from "node:os";
 import assert from "node:assert/strict";
 import {
   assertSemver,
@@ -6,23 +7,10 @@ import {
   binaryVersionTest,
   runCommandInContainer,
 } from "./index.ts";
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
 
 describe("Dataloader languages", () => {
-  describe("Python", () => {
-    binaryVersionTest({
-      binary: "python3",
-      semver: "^3.11",
-      prefix: "Python",
-    });
-
-    binaryOnPathTest({ binary: "pip" });
-
-    test(`A Python virtual environment is activated`, async () => {
-      // should not throw
-      await runCommandInContainer(["pip", "install", "requests"]);
-    });
-  });
-
   describe("JavaScript", () => {
     binaryVersionTest({ binary: "node", semver: "^20.17" });
     binaryVersionTest({ binary: "npm", semver: "^10.5" });
@@ -54,6 +42,63 @@ describe("Dataloader languages", () => {
       binary: "pnpm",
       semver: "^9.10",
       expectStderr: /^! Corepack is about to download.*pnpm/,
+    });
+  });
+
+  describe("Python", () => {
+    binaryVersionTest({
+      binary: "python3",
+      semver: "^3.11",
+      prefix: "Python",
+    });
+
+    binaryVersionTest({
+      binary: "pip",
+      semver: "^23.0.1",
+      extract: /^pip ([^ ]+) /,
+    });
+    binaryVersionTest({ binary: "pipx", semver: "^1.1.0" });
+    binaryVersionTest({
+      binary: "poetry",
+      semver: "^1.8.3",
+      prefix: "Poetry (version ",
+      suffix: ")",
+    });
+
+    test(`A Python virtual environment is activated`, async () => {
+      // should not throw
+      await runCommandInContainer(["pip", "install", "pip-install-test"]);
+    });
+
+    test(`Poetry can install dependencies in the virtualenv`, async () => {
+      let testDir = await mkdtemp(join(os.tmpdir(), "poetry-test-"));
+      try {
+        // This will install dependencies using Poetry, and then try to run `ls`
+        // in the installed dependency's package. If the package is not
+        // installed here, the `ls` command will exit non-zero and
+        // `runCommandInContainer` will throw.
+        await cp(
+          "./tests/fixtures/poetry-test/pyproject.toml",
+          `${testDir}/pyproject.toml`,
+        );
+        let res = await runCommandInContainer(
+          [
+            "sh",
+            "-c",
+            "poetry install; ls $(poetry env info --path)/lib/python3.11/site-packages/pip_install_test/__init__.py",
+          ],
+          {
+            workingDir: "/poetry-test",
+            mounts: [{ host: testDir, container: "/poetry-test" }],
+          },
+        );
+      } finally {
+        try {
+          await rm(testDir, { recursive: true });
+        } catch {
+          /* ok */
+        }
+      }
     });
   });
 

--- a/tests/fixtures/poetry-test/pyproject.toml
+++ b/tests/fixtures/poetry-test/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.11"
+pip-install-test = "^0.5"


### PR DESCRIPTION
This makes sure that Poetry is installed and that it can successfully install dependencies. Normally Poetry makes and manages its own virtualenvs, but we don't really want that here. The bulk of the new tests validate that when Poetry installs dependencies it does it in the existing virtualenv. It does this because we already have an activated virtualenv in the Docker image.
